### PR TITLE
📝 Changed npm -g to npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,17 @@
-## Installation
-
-```sh
-$ npm install -g ironmaker
-```
-
-If your terminal displays permission errors, you might not have administrator privileges. To get around this issue, reopen your terminal as an administrator, or run the following command instead:
-
-```sh
-$ sudo npm install -g ironmaker
-```
-
 ## Quick Start
 
 To create an app, run the following command and follow the instructions you're given:
 
-```bash
-$ ironmaker
+```sh
+npx ironmaker
+cd my-app
+npm install
 ```
 
-Install dependencies:
+If you've previously installed `ironmaker` globally via `npm install -g ironmaker`, we recommend you uninstall the package using `npm uninstall -g ironmaker` or `yarn global remove ironmaker` to ensure that npx always uses the latest version.
 
-```bash
-$ npm install
-```
+_([npx](https://medium.com/@maybekatz/introducing-npx-an-npm-package-runner-55f7d4bd282b) comes with npm 5.2+ and higher, see [instructions for older npm versions](https://gist.github.com/gaearon/4064d3c23a77c74a3614c498a8bb1c5f))_
+
 
 To run the app in development mode:
 


### PR DESCRIPTION
Installing things with `npm -g` is a surefire way to ensure you'll end up with an outdated version of the software.

`npx` is pretty neat, it's ideal for executables that are meant to be run anywhere on bash; it's pretty ideal for this project.